### PR TITLE
chore: skip SEV-SNP enabled nodes for now

### DIFF
--- a/data/blacklist.yaml
+++ b/data/blacklist.yaml
@@ -7,3 +7,9 @@ features:
   - feature: node_provider
     value: g7dkt-aapqq-j3hqt-xtiys-pwapz-idulp-nwagd-zibqm-caxa4-gc23t-3qe
     explanation: Freeing up Antwerp nodes
+  - feature: node_id
+    value: 33mvi-izcix-iv5ys-fypko-b4fwq-w3uns-s3tbl-5ij6h-qvxsf-nm3gb-fqe
+    explanation: Requested to not assign to any subnets still
+  - feature: node_id
+    value: hckfw-kshvv-mzhew-h6isd-5q2wd-lde6w-uipmv-7gbuz-53wqz-cz5kx-oqe
+    explanation: Requested to not assign to any subnets still


### PR DESCRIPTION
Since the feature is still under testing we were requested not to assign these nodes to the subnets still.